### PR TITLE
Use constexpr instead of const for float initialization

### DIFF
--- a/Mercator/BasePoint.cpp
+++ b/Mercator/BasePoint.cpp
@@ -6,8 +6,8 @@
 
 namespace Mercator { 
 
-const float BasePoint::HEIGHT = 8.0;
-const float BasePoint::ROUGHNESS = 1.25;
-const float BasePoint::FALLOFF = 0.25;
+constexpr float BasePoint::HEIGHT = 8.0;
+constexpr float BasePoint::ROUGHNESS = 1.25;
+constexpr float BasePoint::FALLOFF = 0.25;
 
 } //namespace Mercator

--- a/Mercator/Terrain.cpp
+++ b/Mercator/Terrain.cpp
@@ -26,7 +26,7 @@ namespace Mercator {
 
 const unsigned int Terrain::DEFAULT = 0x0000;
 const unsigned int Terrain::SHADED = 0x0001;
-const float Terrain::defaultLevel = 8.f;
+constexpr float Terrain::defaultLevel = 8.f;
 
 /// \brief Construct a new Terrain object with optional options and resolution.
 ///


### PR DESCRIPTION
Ensure compliance with C++11, and consistency with C++11 used elsewhere in the codebase.
